### PR TITLE
Filetype enhancements

### DIFF
--- a/ftplugin/gentoo-conf-d.vim
+++ b/ftplugin/gentoo-conf-d.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/sh.vim

--- a/ftplugin/gentoo-env-d.vim
+++ b/ftplugin/gentoo-env-d.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/sh.vim

--- a/ftplugin/gentoo-init-d.vim
+++ b/ftplugin/gentoo-init-d.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/sh.vim

--- a/ftplugin/gentoo-make-conf.vim
+++ b/ftplugin/gentoo-make-conf.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/sh.vim

--- a/ftplugin/gentoo-package-keywords.vim
+++ b/ftplugin/gentoo-package-keywords.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim

--- a/ftplugin/gentoo-package-license.vim
+++ b/ftplugin/gentoo-package-license.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim

--- a/ftplugin/gentoo-package-mask.vim
+++ b/ftplugin/gentoo-package-mask.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim

--- a/ftplugin/gentoo-package-properties.vim
+++ b/ftplugin/gentoo-package-properties.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim

--- a/ftplugin/gentoo-package-use.vim
+++ b/ftplugin/gentoo-package-use.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim

--- a/ftplugin/gentoo-use-desc.vim
+++ b/ftplugin/gentoo-use-desc.vim
@@ -1,0 +1,5 @@
+if &compatible || v:version < 603
+    finish
+endif
+
+runtime! ftplugin/conf.vim


### PR DESCRIPTION
I added filetypes for various Gentoo files that derive from `conf.vim` or `sh.vim`, as appropriate.
This means that users now get a sensible `commentstring` and other settings that are consistent with other config/shell files.
This pull request fixes Gentoo bug [253653](https://bugs.gentoo.org/show_bug.cgi?id=253653).
