### PR TITLE
add tags file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Copyright 2017-2020 Gentoo Authors
+/doc/tags


### PR DESCRIPTION
I use this plugin directly from the git repository without running `make install`. Generating the helptags for this plugin produces the file `/doc/tags` so I have local changes after generating the help tags. Adding the file to gitignore fixes the problem.