### PR TITLE
Remove $Id$ from ebuild header

### DIFF
--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -34,7 +34,6 @@ fun! GentooHeader(...)
         0 put =l:copyright
     endif
     put ='# Distributed under the terms of the GNU General Public License v2'
-    put ='# $Id$'
     $
 endfun
 


### PR DESCRIPTION
Ref: https://archives.gentoo.org/gentoo-dev/message/993bb2ec7107d4a05d07109d773fb1d9