### PR TITLE
GLEP syntax / file support updates

### DIFF
--- a/ftdetect/gentoo.vim
+++ b/ftdetect/gentoo.vim
@@ -19,7 +19,7 @@ au BufNewFile,BufRead *.e{build,class}
 
 " GLEPs
 au BufNewFile,BufRead *.txt,*.rst
-    \ if (getline(1) =~? "^GLEP: ") |
+    \ if (getline(1) =~? "^GLEP: " || getline(2) =~? "^GLEP: ") |
     \     set filetype=glep |
     \ endif
 

--- a/ftdetect/gentoo.vim
+++ b/ftdetect/gentoo.vim
@@ -18,7 +18,7 @@ au BufNewFile,BufRead *.e{build,class}
     \     set filetype=ebuild
 
 " GLEPs
-au BufNewFile,BufRead *.txt
+au BufNewFile,BufRead *.txt,*.rst
     \ if (getline(1) =~? "^GLEP: ") |
     \     set filetype=glep |
     \ endif

--- a/plugin/newglep.vim
+++ b/plugin/newglep.vim
@@ -1,0 +1,104 @@
+" Vim plugin
+" Purpose:      New GLEP skeleton
+" Author:       Michał Górny <mgorny@gentoo.org>
+" Copyright:    Copyright (c) 2017 Michał Górny
+" Licence:      You may redistribute this under the same terms as Vim itself
+
+if &compatible || v:version < 603 || exists("g:loaded_newglep")
+    finish
+endif
+
+let g:loaded_newglep=1
+
+runtime! plugin/gentoo-common.vim
+
+fun! <SID>MakeNewGLEP()
+    let l:pastebackup = &paste
+    set nopaste
+
+    " {{{ variables
+    let l:filename = expand("%:t")
+    let l:basename = expand("%:t:r")
+    let l:number = str2nr(substitute(l:basename, "^glep-", "", ""))
+    let l:date = strftime("%Y-%m-%d")
+    " }}}
+
+    " {{{ header preamble
+    put ='---'
+    put ='GLEP: ' . l:number
+    put ='Title: '
+    put ='Author: ' . GentooGetUser()
+    put ='Type: Standards Track'
+    put ='Status: Draft'
+    put ='Version: 1'
+    put ='Created: ' . l:date
+    put ='Last-Modified: ' . l:date
+    put ='Post-History: '
+    put ='Content-Type: text/x-rst'
+    put ='Requires: '
+    put ='Replaces: '
+    put ='---'
+    " }}}
+
+    " {{{ warn if .txt suffix is used
+    if l:filename =~# ".txt\$"
+        put =''
+        put ='.. Warning: .txt suffix is obsolete, use \"' . l:basename . '.rst\" instead'
+    endif
+    " }}}
+
+    " {{{ skeleton
+    let l:sections = ['Abstract', 'Motivation', 'Specification', 'Rationale',
+        \ 'Backwards Compatibility', 'Reference Implementation', 'References',
+        \ 'Copyright']
+    for l:section in l:sections
+        let l:sectlen = len(l:section)
+        put =''
+        put =l:section
+        put =repeat('=', l:sectlen)
+        if l:section != 'Copyright'
+            put =''
+            put =''
+            put =''
+        endif
+    endfor
+    " copyright
+    put ='This work is licensed under the Creative Commons Attribution-ShareAlike 3.0'
+    put ='Unported License. To view a copy of this license, visit'
+    put ='http://creativecommons.org/licenses/by-sa/3.0/.'
+    " }}}
+
+    " {{{ go to the first thing to edit
+    0
+    del
+    /^Title:/
+    normal $
+    nohls
+    " }}}
+
+    if pastebackup == 0
+        set nopaste
+    endif
+endfun
+
+com! -nargs=0 NewGLEP call <SID>MakeNewGLEP() | set filetype=glep
+
+if !exists("g:glep_create_on_empty")
+    " Enable autogeneration of GLEPs by default
+    let g:glep_create_on_empty = 1
+endif
+
+" check to see if v:progname is vimdiff to disable new GLEP creation
+if v:progname =~ "vimdiff"
+    let g:glep_create_on_empty = 0
+endif
+
+augroup NewGLEP
+    au!
+    autocmd BufNewFile glep-[0-9][0-9][0-9][0-9].{txt,rst}
+                \ if g:glep_create_on_empty |
+                \    call <SID>MakeNewGLEP() | set filetype=glep |
+                \ endif
+augroup END
+
+" vim: set et foldmethod=marker : "

--- a/syntax/glep.vim
+++ b/syntax/glep.vim
@@ -33,6 +33,7 @@ syn region glepFoldH4 start=/^\S.\+\n'\{2,\}$/ end=/\(\n\n\S.\+\n[-=']\{2,\}\)\@
 
 " Headers at the top of a GLEP
 syn region glepHeaders start=/\%^\(.*:\)\@=/ end=/^$/ contains=glepHeaderKey
+syn region glepTripleDash start=/\%^---$/ end=/^---$/ contains=glepHeaderKey
 syn region glepHeaderKey contained start=/^[A-Za-z0-9]/ end=/:/ nextgroup=glepHeaderValue skipwhite
 syn region glepHeaderValue contained start=/\S/ end=/$/ contains=glepHeaderEmail,glepHeaderCVSVar
 syn match  glepHeaderEmail contained /<[-a-zA-Z0-9\_\.]\+@[-a-zA-Z0-9\_\.]\+>/
@@ -51,6 +52,7 @@ hi  link glepHeading4       Preproc
 hi  link glepHeading5       Special
 
 hi  link glepHeaders        Define
+hi  link glepTripleDash     Define
 hi  link glepHeaderKey      Keyword
 hi  link glepHeaderValue    String
 hi  link glepHeaderEmail    Special


### PR DESCRIPTION
Here's a bunch of syntax updates for the new GLEP workflow:
* support for `.rst` suffix and YAML-like preamble,
* <del>handle header continuations correctly (this one can be cherry-picked for the old format if somebody cares)</del> [moved to PR #15],
* add a `newglep` plugin that fills a nice skeleton in.