### PR TITLE
Add trim for GentooGetUser()

### DIFF
--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -13,8 +13,8 @@ let g:loaded_gentoo_common=1
 fun! GentooGetUser()
     let l:result = expand("\$ECHANGELOG_USER")
     if l:result ==# "\$ECHANGELOG_USER"
-        let l:email = executable('git') ? system('git config --global user.email') : expand('$HOST')
-        let l:name = executable('git') ? system('git config --global user.name') : expand('$USER')
+        let l:email = executable('git') ? trim(system('git config --global user.email')) : expand('$HOST')
+        let l:name = executable('git') ? trim(system('git config --global user.name')) : expand('$USER')
         let l:result = l:name . ' <' . l:email . '>'
     endif
     return l:result


### PR DESCRIPTION
sorry for my disturbance!
i read <https://github.com/honza/vim-snippets/blob/d4c285e8e7b482db810f453a308d45f259facbf9/plugin/vimsnippets.vim#L14>, and find <https://github.com/gentoo/gentoo-syntax/blob/master/plugin/gentoo-common.vim#L17> exists some bug.

```{.vim}
echo system('git config --global user.name')
```

will return
![image](https://user-images.githubusercontent.com/32936898/94022301-89d60a00-fde7-11ea-8be6-a061174f17fe.png)

there exists a "\n" in the last character of the string.

`trim()` will remove the invisiable character of the string.

```{.vim}
echo trim(system('git config --global user.name'))
```

![image](https://user-images.githubusercontent.com/32936898/94024764-5ea0ea00-fdea-11ea-91a1-1b0f4ab51fb3.png)

Thanks!