### PR TITLE
gentoo-common: PYTHON_TARGETS generation improvements

### DIFF
--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -67,17 +67,16 @@ fun! GentooGetPythonTargets()
         if filereadable(l:pyexec_path)
             let l:pys = readfile(l:pyexec_path)->filter("v:val =~ '^[^#-]'")
                                              \ ->sort()
+            let l:impls = []
             let l:py3s = []
-            let l:others = []
             for l:py in l:pys
                 let l:m = l:py->matchstr("^python3.*")->matchstr("\\d*$")
                 if !empty(l:m)
                     eval l:py3s->add(l:m)
                 else
-                    eval l:others->add(l:py)
+                    eval l:impls->add(l:py)
                 endif
             endfor
-            let l:impls = []
             if len(l:py3s) ==# 1
                 let l:impls = l:impls->add("python3_".l:py3s->join())
             elseif len(l:py3s) > 1
@@ -104,7 +103,7 @@ fun! GentooGetPythonTargets()
                                        \ ->join(",")."}")
                 endif
             endif
-            let l:py3 = flatten(l:impls->add(l:others))->join()
+            let l:py3 = flatten(l:impls)->join()
         endif
         if empty(l:py3)
             let l:py3 =

--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -73,7 +73,6 @@ fun! GentooGetPythonTargets()
                 let l:m = l:py->matchstr("^python3.*")->matchstr("\\d*$")
                 if !empty(l:m)
                     eval l:py3s->add(l:m)
-                    continue
                 else
                     eval l:others->add(l:py)
                 endif

--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -80,22 +80,40 @@ fun! GentooGetPythonTargets()
             endfor
             let l:impls = []
             if len(l:py3s) ==# 1
-                let l:impls = l:impls->add("python3.".l:py3s->join())
+                let l:impls = l:impls->add("python3_".l:py3s->join())
             elseif len(l:py3s) > 1
-                let l:impls = l:impls->add("python3.{".l:py3s->sort('N')
-                                   \ ->join(",")."}")
+                let l:min = ""
+                let l:max = ""
+                let l:py3s = l:py3s->sort('N')
+                for l:py in l:py3s
+                    if l:min ==# ""
+                        let l:min = l:py
+                        let l:max = l:py
+                    elseif l:py ==# l:max + 1
+                        let l:max = l:py
+                    else
+                        let l:max = ""
+                        break
+                    endif
+                endfor
+
+                if l:max !=# ""
+                    let l:impls = l:impls->add("python3_{".l:min.".."
+                                             \ .l:max."}")
+                else
+                    let l:impls = l:impls->add("python3_{".l:py3s
+                                       \ ->join(",")."}")
+                endif
             endif
             let l:py3 = flatten(l:impls->add(l:others))->join()
         endif
         if empty(l:py3)
             let l:py3 =
                 \ system("python -c 'import epython; print(epython.EPYTHON)'")
-                \ ->substitute("\n", "", "g")
+                \ ->substitute("\n", "", "g")->substitute("[.]", "_", "g")
         endif
 
-        let l:pythons = substitute(l:py3, "[.]", "_", "g")
-
-        let g:gentoopythontargets = l:pythons
+        let g:gentoopythontargets = l:py3
         return g:gentoopythontargets
     endif
 endfun

--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -78,11 +78,11 @@ fun! GentooGetPythonTargets()
                 endif
             endfor
             if len(l:py3s) ==# 1
-                let l:impls = l:impls->add("python3_".l:py3s->join())
+                eval l:impls->add("python3_".l:py3s->join())
             elseif len(l:py3s) > 1
                 let l:min = ""
                 let l:max = ""
-                let l:py3s = l:py3s->sort('N')
+                eval l:py3s->sort('N')
                 for l:py in l:py3s
                     if l:min ==# ""
                         let l:min = l:py
@@ -96,11 +96,9 @@ fun! GentooGetPythonTargets()
                 endfor
 
                 if l:max !=# ""
-                    let l:impls = l:impls->add("python3_{".l:min.".."
-                                             \ .l:max."}")
+                    eval l:impls->add("python3_{".l:min."..".l:max."}")
                 else
-                    let l:impls = l:impls->add("python3_{".l:py3s
-                                       \ ->join(",")."}")
+                    eval l:impls->add("python3_{".l:py3s->join(",")."}")
                 endif
             endif
             let l:py3 = flatten(l:impls)->join()


### PR DESCRIPTION
Teach the code to combine subsequent Python versions, i.e. instead of:

    PYTHON_COMPAT=( python3_{8,9,10} )

output:

    PYTHON_COMPAT=( python3_{8..10} )

While at it, simplify the code some.

CC @msva, @gentoo/python