### PR TITLE
Add Syntastic support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ files = $(wildcard \
 	indent/* \
 	plugin/* \
 	syntax/* \
+	syntax_checkers/* \
 )
 
 scripts: ${files}

--- a/ftdetect/gentoo.vim
+++ b/ftdetect/gentoo.vim
@@ -31,20 +31,20 @@ au BufNewFile,BufRead ChangeLog*
 
 " /etc/init.d/ scripts
 au BufNewFile,BufRead /etc/init.d/*
-    \     set filetype=gentoo-init-d |
+    \     set filetype=gentoo-init-d.sh |
 
 au BufNewFile,BufRead *
     \ if (getline(1) =~? "#!/sbin/\\(runscript\\|openrc-run\\)") |
-    \     set filetype=gentoo-init-d |
+    \     set filetype=gentoo-init-d.sh |
     \ endif
 
 " /etc/conf.d/ scripts
 au BufNewFile,BufRead /etc/conf.d/*
-    \     set filetype=gentoo-conf-d
+    \     set filetype=gentoo-conf-d.sh
 
 " /etc/env.d/ scripts
 au BufNewFile,BufRead /etc/env.d/*
-    \     set filetype=gentoo-env-d
+    \     set filetype=gentoo-env-d.sh
 
 " /etc/cron.d/ scripts
 au BufNewFile,BufRead /etc/cron.d/*

--- a/plugin/newinitd.vim
+++ b/plugin/newinitd.vim
@@ -37,12 +37,12 @@ fun! <SID>MakeNewInitd()
     0
 endfun
 
-com! -nargs=0 NewInitd call <SID>MakeNewInitd() | set filetype=gentoo-init-d
+com! -nargs=0 NewInitd call <SID>MakeNewInitd() | set filetype=gentoo-init-d.sh
 
 augroup NewInitd
     au!
     autocmd BufNewFile {/*/files/*.{rc*,init*},/etc/init.d/*}
-        \ call <SID>MakeNewInitd() | set filetype=gentoo-init-d
+        \ call <SID>MakeNewInitd() | set filetype=gentoo-init-d.sh
 augroup END
 
 " vim: set et foldmethod=marker : "

--- a/syntax_checkers/ebuild/pkgcheck.vim
+++ b/syntax_checkers/ebuild/pkgcheck.vim
@@ -1,0 +1,52 @@
+" Syntax checking plugin for syntastic
+" Language:	Gentoo Ebuilds/Eclasses
+" Author:	Anna Vyalkova <cyber+gentoo@sysrq.in>
+" Copyright:	Copyright (c) 2022 Anna Vyalkova
+" Licence:	You may redistribute this under the same terms as Vim itself
+"
+" Syntax checker for ebuilds and eclasses powered by pkgcheck.
+" Requires vim 7.0.175 or later.
+"
+
+if exists('g:loaded_syntastic_ebuild_pkgcheck_checker')
+    finish
+endif
+let g:loaded_syntastic_ebuild_pkgcheck_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_ebuild_pkgcheck_GetLocList() dict
+    let makeprg = self.makeprgBuild({
+	\ 'args_before': 'scan',
+	\ 'args': '-R FormatReporter',
+	\ 'args_after': '--format "{lineno}:{level}:{name}: {desc}"' })
+
+    let errorformat =
+        \ '%l:%tnfo:%m,'    . ':%tnfo:%m,' .
+        \ '%W%l:style:%m,'  . '%W:style:%m,' .
+        \ '%l:%tarning:%m,' . ':%tarning:%m,' .
+        \ '%l:%trror:%m,'   . ':%trror:%m'
+
+    let loclist = SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat,
+        \ 'defaults': {'bufnr': bufnr(''), 'type': 'E', 'text': 'Syntax error'},
+        \ 'returns': [0, 1] })
+
+    for e in loclist
+        if e['valid'] && e['lnum'] == 0
+            let e['lnum'] = str2nr(matchstr(e['text'], '\m\<lines\? \zs\d\+\ze'))
+        endif
+    endfor
+
+    return loclist
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'ebuild',
+    \ 'name': 'pkgcheck',
+    \ 'exec': 'pkgcheck'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
Some optfeature calls can be added to the ebuild, like:

```sh
optfeature "checking ebuilds and eclasses for QA issues" "app-vim/syntastic dev-util/pkgcheck"
optfeature "detecting bashisms in OpenRC scripts" "app-vim/syntastic dev-util/checkbashisms"
```