### PR TITLE
newebuild: put inherit guard variable immediately after check

### DIFF
--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -49,13 +49,13 @@ fun! <SID>MakeNewEbuild()
         put =''
         let l:eclass_ident = substitute(toupper(l:eclass), "[^A-Z0-9]", "_", "g")
         put ='if [[ ! ${_' . l:eclass_ident . '} ]]; then'
+        put ='_' . l:eclass_ident . '=1'
         put =''
         put ='case ${EAPI} in'
         put ='	8) ;;'
         put ='	*) die \"${ECLASS}: EAPI ${EAPI} unsupported.\"'
         put ='esac'
         put =''
-        put ='_' . l:eclass_ident . '=1'
         put ='fi'
         " }}}
 

--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -47,14 +47,14 @@ fun! <SID>MakeNewEbuild()
         put ='# @BLURB: '
         put ='# @DESCRIPTION:'
         put =''
-        let l:eclass_ident = substitute(toupper(l:eclass), "[^A-Z0-9]", "_", "g")
-        put ='if [[ ! ${_' . l:eclass_ident . '} ]]; then'
-        put ='_' . l:eclass_ident . '=1'
-        put =''
         put ='case ${EAPI} in'
         put ='	8) ;;'
         put ='	*) die \"${ECLASS}: EAPI ${EAPI} unsupported.\"'
         put ='esac'
+        put =''
+        let l:eclass_ident = substitute(toupper(l:eclass), "[^A-Z0-9]", "_", "g")
+        put ='if [[ ! ${_' . l:eclass_ident . '} ]]; then'
+        put ='_' . l:eclass_ident . '=1'
         put =''
         put ='fi'
         " }}}


### PR DESCRIPTION
For new eclasses, the provided template puts the variable at the end of
the body, but the current preference is to assign the variable
immediately after the check.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>