### PR TITLE
Update newebuild.vim

### DIFF
--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -135,10 +135,10 @@ fun! <SID>MakeNewEbuild()
             put =''
             put ='CP_DEPEND=\"\"'
             put =''
-            put ='RDEPEND=\">=virtual/jre-1.8'
-            put ='  ${CP_DEPEND}\"'
-            put ='DEPEND=\">=virtual/jdk-1.8'
-            put ='  ${CP_DEPEND}\"'
+            put ='RDEPEND=\">=virtual/jre-1.8:*'
+            put ='	${CP_DEPEND}\"'
+            put ='DEPEND=\">=virtual/jdk-1.8:*'
+            put ='	${CP_DEPEND}\"'
         elseif l:category ==# "dev-perl" || l:category ==# "perl-core"
             " {{{ perl modules default setup
             put ='DIST_AUTHOR=\"\"'


### PR DESCRIPTION
In plugin/newebuild.vim, add the missing slot operators in >=virtual/jdk-1.8:* and >=virtual/jre-1.8:* according to Java packaging policy.