### PR TITLE
GentooGetUser(): Drop --global option for git config

### DIFF
--- a/plugin/gentoo-common.vim
+++ b/plugin/gentoo-common.vim
@@ -13,7 +13,7 @@ let g:loaded_gentoo_common=1
 fun! GentooGetUser()
     let l:result = expand("\$ECHANGELOG_USER")
     if l:result ==# "\$ECHANGELOG_USER"
-        let l:gitcfg = "git config --global "
+        let l:gitcfg = "git config "
         if executable("git")
             let l:email = trim(system(l:gitcfg . "user.email"))
             let l:name = trim(system(l:gitcfg . "user.name"))


### PR DESCRIPTION
Omitting the --global option when obtaining git config values results in git returning the repo-local config option, if set, and the global value otherwise. This allows devs with a repo-specific git config (e.g. with an alternate E-Mail address for Gentoo-specific projects) to have the correct email address e.g. for creating metadata.xml retrieved automatically.