### PR TITLE
newebuild: Use standard clause for unsupported EAPI in new eclasses

### DIFF
--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -49,7 +49,7 @@ fun! <SID>MakeNewEbuild()
         put =''
         put ='case ${EAPI} in'
         put ='	8) ;;'
-        put ='	*) die \"${ECLASS}: EAPI ${EAPI} unsupported.\"'
+        put ='	*) die \"${ECLASS}: EAPI ${EAPI:-0} not supported\" ;;'
         put ='esac'
         put =''
         let l:eclass_ident = substitute(toupper(l:eclass), "[^A-Z0-9]", "_", "g")


### PR DESCRIPTION
Signed-off-by: Michał Górny <mgorny@gentoo.org>