### PR TITLE
Enable syntax detection for make.conf as a directory

### DIFF
--- a/ftdetect/gentoo.vim
+++ b/ftdetect/gentoo.vim
@@ -75,7 +75,7 @@ au BufNewFile,BufRead {*/thirdpartymirrors,*/portage/mirrors}
     \     set filetype=gentoo-mirrors
 
 " make.conf
-au BufNewFile,BufRead make.{conf,globals}
+au BufNewFile,BufRead {*/make.{conf,globals},*/portage/make.conf/*}
     \     set filetype=gentoo-make-conf
 
 " use.desc


### PR DESCRIPTION
Technically, make.conf can be a directory, and I use it as one :). Niche use case but works \o/

Signed-off-by: Richard Rogalski <rrogalski@tutanota.com>