### PR TITLE
Add more eclasses and some EAPI=7 functions

### DIFF
--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -262,6 +262,12 @@ syn keyword EbuildUnpackerKeyword unpack_pdv unpack_makeself
 syn keyword EbuildDeprecatedKeyword enewuser enewgroup
 syn keyword EbuildUserKeyword egetent
 
+" cmake
+syn keyword EbuildCMakeKeyword cmake_run_in cmake_comment_add_subdirectory cmake_use_find_package
+syn keyword EbuildCMakeKeyword cmake_build mycmakeargs MYCMAKEARGS
+syn keyword EbuildCMakeKeyword cmake_src_prepare cmake_src_configure cmake_src_compile
+syn keyword EbuildCMakeKeyword cmake_src_test cmake_src_install
+
 " EXPORT_FUNCTIONS
 syn match EbuildExportFunctions /EXPORT_FUNCTIONS/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
 syn match EbuildExportFunctionsFunc contained /\S\+\(\s\|$\)\@=/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
@@ -331,6 +337,7 @@ syn cluster EbuildThings add=EbuildDependApacheKeyword,EbuildApacheModuleKeyword
 syn cluster EbuildThings add=EbuildVirtualXKeyword,EbuildGnome2Keyword,EbuildAutoKeyword
 syn cluster EbuildThings add=EbuildDeprecatedKeyword,EbuildUnpackerKeyword,EbuildUserKeyword
 syn cluster EbuildThings add=EbuildCDROMKeyword,EbuildLinuxInfoKeyword,EbuildDistutilsFunction
+syn cluster EbuildThings add=EbuildCMakeKeyword
 
 syn cluster shCommandSubList add=@EbuildThings
 syn cluster shCommentGroup add=GentooBug
@@ -372,6 +379,7 @@ hi def link EbuildCDROMKeyword               Identifier
 hi def link EbuildLinuxInfoKeyword           Identifier
 hi def link EbuildUnpackerKeyword            Identifier
 hi def link EbuildUserKeyword                Identifier
+hi def link EbuildCMakeKeyword               Identifier
 hi def link EbuildDistutilsFunction          Special
 
 hi def link EclassDocumentationTag           Identifier

--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -38,6 +38,7 @@ syn keyword EbuildCoreKeyword doinitd doconfd doenvd domo dodir ebegin eend
 syn keyword EbuildCoreKeyword newconfd newdoc newenvd newinitd newlib.a newlib.so
 syn keyword EbuildCoreKeyword hasv usev usex elog eapply eapply_user
 syn keyword EbuildCoreKeyword einstalldocs in_iuse get_libdir
+syn keyword EbuildCoreKeyword dostrip ver_cut ver_rs ver_test
 
 " Deprecated and banned functions
 syn keyword EbuildDeprecatedKeyword check_KV dohard dohtml prepall prepalldocs

--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -275,6 +275,9 @@ syn keyword EbuildTmpfilesKeyword dotmpfiles newtmpfiles tmpfiles_process
 syn keyword EbuildUdevKeyword get_udevdir udev_dorules udev_newrules udev_reload
 syn keyword EbuildDeprecatedKeyword udev_get_udevdir
 
+" check-reqs
+syn keyword EbuildCheckReqsKeyword check-reqs_pkg_setup check-reqs_pkg_pretend
+
 " EXPORT_FUNCTIONS
 syn match EbuildExportFunctions /EXPORT_FUNCTIONS/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
 syn match EbuildExportFunctionsFunc contained /\S\+\(\s\|$\)\@=/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
@@ -344,7 +347,8 @@ syn cluster EbuildThings add=EbuildDependApacheKeyword,EbuildApacheModuleKeyword
 syn cluster EbuildThings add=EbuildVirtualXKeyword,EbuildGnome2Keyword,EbuildAutoKeyword
 syn cluster EbuildThings add=EbuildDeprecatedKeyword,EbuildUnpackerKeyword,EbuildUserKeyword
 syn cluster EbuildThings add=EbuildCDROMKeyword,EbuildLinuxInfoKeyword,EbuildDistutilsFunction
-syn cluster EbuildThings add=EbuildCMakeKeyword,EbuildTmpfilesKeyword,EbuildUdevKeyword
+syn cluster EbuildThings add=EbuildCMakeKeyword,EbuildCMakeFunction,EbuildTmpfilesKeyword
+syn cluster EbuildThings add=EbuildUdevKeyword,EbuildCheckReqsKeyword
 
 syn cluster shCommandSubList add=@EbuildThings
 syn cluster shCommentGroup add=GentooBug
@@ -389,6 +393,7 @@ hi def link EbuildUserKeyword                Identifier
 hi def link EbuildCMakeKeyword               Identifier
 hi def link EbuildTmpfilesKeyword            Identifier
 hi def link EbuildUdevKeyword                Identifier
+hi def link EbuildCheckReqsKeyword           Identifier
 hi def link EbuildDistutilsFunction          Special
 
 hi def link EclassDocumentationTag           Identifier

--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -268,6 +268,9 @@ syn keyword EbuildCMakeKeyword cmake_build mycmakeargs MYCMAKEARGS
 syn keyword EbuildCMakeKeyword cmake_src_prepare cmake_src_configure cmake_src_compile
 syn keyword EbuildCMakeKeyword cmake_src_test cmake_src_install
 
+" tmpfiles
+syn keyword EbuildTmpfilesKeyword dotmpfiles newtmpfiles tmpfiles_process
+
 " EXPORT_FUNCTIONS
 syn match EbuildExportFunctions /EXPORT_FUNCTIONS/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
 syn match EbuildExportFunctionsFunc contained /\S\+\(\s\|$\)\@=/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
@@ -337,7 +340,7 @@ syn cluster EbuildThings add=EbuildDependApacheKeyword,EbuildApacheModuleKeyword
 syn cluster EbuildThings add=EbuildVirtualXKeyword,EbuildGnome2Keyword,EbuildAutoKeyword
 syn cluster EbuildThings add=EbuildDeprecatedKeyword,EbuildUnpackerKeyword,EbuildUserKeyword
 syn cluster EbuildThings add=EbuildCDROMKeyword,EbuildLinuxInfoKeyword,EbuildDistutilsFunction
-syn cluster EbuildThings add=EbuildCMakeKeyword
+syn cluster EbuildThings add=EbuildCMakeKeyword,EbuildTmpfilesKeyword
 
 syn cluster shCommandSubList add=@EbuildThings
 syn cluster shCommentGroup add=GentooBug
@@ -380,6 +383,7 @@ hi def link EbuildLinuxInfoKeyword           Identifier
 hi def link EbuildUnpackerKeyword            Identifier
 hi def link EbuildUserKeyword                Identifier
 hi def link EbuildCMakeKeyword               Identifier
+hi def link EbuildTmpfilesKeyword            Identifier
 hi def link EbuildDistutilsFunction          Special
 
 hi def link EclassDocumentationTag           Identifier

--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -271,6 +271,10 @@ syn keyword EbuildCMakeKeyword cmake_src_test cmake_src_install
 " tmpfiles
 syn keyword EbuildTmpfilesKeyword dotmpfiles newtmpfiles tmpfiles_process
 
+" udev
+syn keyword EbuildUdevKeyword get_udevdir udev_dorules udev_newrules udev_reload
+syn keyword EbuildDeprecatedKeyword udev_get_udevdir
+
 " EXPORT_FUNCTIONS
 syn match EbuildExportFunctions /EXPORT_FUNCTIONS/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
 syn match EbuildExportFunctionsFunc contained /\S\+\(\s\|$\)\@=/ skipwhite nextgroup=EbuildExportFunctionsFunc,EbuildExportFunctionsFuncE
@@ -340,7 +344,7 @@ syn cluster EbuildThings add=EbuildDependApacheKeyword,EbuildApacheModuleKeyword
 syn cluster EbuildThings add=EbuildVirtualXKeyword,EbuildGnome2Keyword,EbuildAutoKeyword
 syn cluster EbuildThings add=EbuildDeprecatedKeyword,EbuildUnpackerKeyword,EbuildUserKeyword
 syn cluster EbuildThings add=EbuildCDROMKeyword,EbuildLinuxInfoKeyword,EbuildDistutilsFunction
-syn cluster EbuildThings add=EbuildCMakeKeyword,EbuildTmpfilesKeyword
+syn cluster EbuildThings add=EbuildCMakeKeyword,EbuildTmpfilesKeyword,EbuildUdevKeyword
 
 syn cluster shCommandSubList add=@EbuildThings
 syn cluster shCommentGroup add=GentooBug
@@ -384,6 +388,7 @@ hi def link EbuildUnpackerKeyword            Identifier
 hi def link EbuildUserKeyword                Identifier
 hi def link EbuildCMakeKeyword               Identifier
 hi def link EbuildTmpfilesKeyword            Identifier
+hi def link EbuildUdevKeyword                Identifier
 hi def link EbuildDistutilsFunction          Special
 
 hi def link EclassDocumentationTag           Identifier


### PR DESCRIPTION
This adds support for these ebuild functions
- `dostrip`
- `ver_cut`
- `ver_rs`
- `ver_test`

As well as support for these eclasses:
- `cmake.eclass`
- `tmpfiles.eclass`
- `udev.eclass`
- `check-reqs.eclass`