### PR TITLE
Improve variables in Java ebuild template

### DIFF
--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -128,7 +128,7 @@ fun! <SID>MakeNewEbuild()
             put =''
             put ='DESCRIPTION=\"\"'
             put ='HOMEPAGE=\"\"'
-            put ='SRC_URI=\"${P}.zip\"'
+            put ='SRC_URI=\"\"'
             put =''
             put ='LICENSE=\"\"'
             put ='SLOT=\"0\"'

--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -122,6 +122,7 @@ fun! <SID>MakeNewEbuild()
         elseif l:category ==# "dev-java"
             " {{{ dev-java generation-2 default java-pkg-simple ebuild
             put ='JAVA_PKG_IUSE=\"doc source\"'
+            put ='MAVEN_ID=\"\"'
             put =''
             put ='inherit java-pkg-2 java-pkg-simple'
             put =''


### PR DESCRIPTION
This PR improves variable declarations and definitions in `dev-java` ebuilds that the `newebuild` plugin creates to better reflect what a typical `dev-java` ebuild in `::gentoo` looks like.