### PR TITLE
Update templates for Python ebuilds

### DIFF
--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -187,7 +187,8 @@ fun! <SID>MakeNewEbuild()
 
             " {{{ extra deps for some categories
             if l:category ==# "dev-python"
-                put ='RDEPEND=\"\"'
+                put ='RDEPEND=\"'
+                put ='\"'
                 put ='BDEPEND=\"'
                 put ='	test? ('
                 put ='	)'

--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -161,7 +161,7 @@ fun! <SID>MakeNewEbuild()
             " {{{ standard default setup
             " {{{ extra inherits for some categories
             if l:category ==# "dev-python"
-                put ='DISTUTILS_USE_PEP517=setuptools'
+                put ='DISTUTILS_USE_PEP517=hatchling'
                 put ='PYTHON_COMPAT=( ' . GentooGetPythonTargets() . ' )'
                 put =''
                 put ='inherit distutils-r1 pypi'

--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -163,6 +163,7 @@ fun! <SID>MakeNewEbuild()
             if l:category ==# "dev-python"
                 put ='DISTUTILS_USE_PEP517=setuptools'
                 put ='PYTHON_COMPAT=( ' . GentooGetPythonTargets() . ' )'
+                put =''
                 put ='inherit distutils-r1 pypi'
                 put =''
             endif

--- a/plugin/newebuild.vim
+++ b/plugin/newebuild.vim
@@ -163,7 +163,7 @@ fun! <SID>MakeNewEbuild()
             if l:category ==# "dev-python"
                 put ='DISTUTILS_USE_PEP517=setuptools'
                 put ='PYTHON_COMPAT=( ' . GentooGetPythonTargets() . ' )'
-                put ='inherit distutils-r1'
+                put ='inherit distutils-r1 pypi'
                 put =''
             endif
             " }}}
@@ -176,9 +176,9 @@ fun! <SID>MakeNewEbuild()
                 put ='\"'
             else
                 put ='HOMEPAGE=\"\"'
+                put ='SRC_URI=\"\"'
             endif
 
-            put ='SRC_URI=\"\"'
             put =''
             put ='LICENSE=\"\"'
             put ='SLOT=\"0\"'

--- a/plugin/newmetadata.vim
+++ b/plugin/newmetadata.vim
@@ -91,6 +91,7 @@ fun! <SID>MakeNewMetadata()
         endif
         put ='</maintainer>'
         if l:category ==# "dev-python"
+            put ='<stabilize-allarches/>'
             put ='<upstream>'
             put ='<remote-id type=\"pypi\">' . l:package . '</remote-id>'
             put ='</upstream>'

--- a/plugin/newmetadata.vim
+++ b/plugin/newmetadata.vim
@@ -61,6 +61,8 @@ fun! <SID>MakeNewMetadata()
             let l:project = "perl"
         elseif l:category ==# "dev-php"
             let l:project = "php-bugs"
+        elseif l:category ==# "dev-python"
+            let l:project = "python"
         elseif l:category ==# "dev-ruby"
             let l:project = "ruby"
         elseif l:category ==# "dev-tex"
@@ -75,6 +77,9 @@ fun! <SID>MakeNewMetadata()
         put ='<!DOCTYPE pkgmetadata SYSTEM \"https://www.gentoo.org/dtd/metadata.dtd\">'
         put ='<pkgmetadata>'
         if l:project != ""
+            if l:project == "python"
+                put ='<!-- please remove python@ if tests do not work -->'
+            endif
             put ='<maintainer type=\"project\">'
             put ='<email>' . l:project . '@gentoo.org</email>'
             put ='</maintainer>'


### PR DESCRIPTION
Some style changes, default to `pypi.eclass`, default to `hatchling`, default to `<stabilize-allarches/>` and list `python@` as proposed maintainer with a comment on tests.

CC @gentoo/python 