### PR TITLE
Forcefully unset b:current_syntax

### DIFF
--- a/syntax/ebuild.vim
+++ b/syntax/ebuild.vim
@@ -19,7 +19,7 @@ endif
 
 let is_bash=1
 runtime! syntax/sh.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 runtime syntax/gentoo-common.vim
 

--- a/syntax/gentoo-conf-d.vim
+++ b/syntax/gentoo-conf-d.vim
@@ -19,7 +19,7 @@ endif
 
 let is_bash=1
 runtime! syntax/sh.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 runtime syntax/gentoo-common.vim
 syn cluster shCommentGroup add=GentooBug

--- a/syntax/gentoo-env-d.vim
+++ b/syntax/gentoo-env-d.vim
@@ -19,7 +19,7 @@ endif
 
 let is_bash=1
 runtime! syntax/sh.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 runtime syntax/gentoo-common.vim
 syn cluster shCommentGroup add=GentooBug

--- a/syntax/gentoo-init-d.vim
+++ b/syntax/gentoo-init-d.vim
@@ -22,7 +22,7 @@ endif
 
 let is_bash=1
 runtime! syntax/sh.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 runtime syntax/gentoo-common.vim
 syn cluster shCommentGroup add=GentooBug

--- a/syntax/gentoo-metadata.vim
+++ b/syntax/gentoo-metadata.vim
@@ -16,7 +16,7 @@ if exists("b:current_syntax")
 endif
 
 runtime! syntax/xml.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 syn cluster xmlTagHook add=metadataElement
 

--- a/syntax/glep.vim
+++ b/syntax/glep.vim
@@ -17,7 +17,7 @@ if exists("b:current_syntax")
 endif
 
 runtime! syntax/rst.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 " Headings in GLEPs (rst doesn't highlight these)
 syn match  glepHeading1 /^\(\(-\{2,\}\|=\{2,\}\|'\{2,\}\)\n\)\S.\+\n\(-\{2,\}\|=\{2,\}\|'\{2,\}\)$/

--- a/syntax/guidexml.vim
+++ b/syntax/guidexml.vim
@@ -16,7 +16,7 @@ if exists("b:current_syntax")
 endif
 
 runtime! syntax/xml.vim
-unlet b:current_syntax
+unlet! b:current_syntax
 
 syn cluster xmlTagHook add=guidexmlElement
 syn keyword guidexmlElement contained mainpage guide news title subtitle


### PR DESCRIPTION
This change forcefully removes `b:current_syntax` from the current buffer and effectively discards the `E108: No such variable: "b:current_syntax"` error created when `b:current_syntax` is not inherited from another syntax file (ie: when `syntax/sh.vim` does not exist).

Error in full:
```
$ vim /etc/init.d/foobar
Error detected while processing /etc/vim/vimrc[92]../base/usr/share/vim/vim90/syntax/syntax.vim[43]..BufRead Autocommands for "/etc/init.d/*"..FileType Autocommands for "*"..Syntax Autocommands for "*"..function <SNR>3_SynSet[25]..script /base/usr/share/vim/vimfiles/syntax/gentoo-init-d.vim:
line   25:
E108: No such variable: "b:current_syntax"
Press ENTER or type command to continue
```